### PR TITLE
Add command to print blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ generators {
 version=1
 ```
 
+Available block IDs can be discovered using the `/genblocksfile` command, which will print the block IDs to a file in the Terrafirma
+config directory (requiring the `terrafirma.dumpblocks` permission). 
+
 The server then needs to be restarted, which will then allow you to create a world with the name "testworld" using the following Nucleus 
 command (other world management plugins will vary)
 

--- a/src/main/java/io/github/nucleuspowered/terrafirma/Terrafirma.java
+++ b/src/main/java/io/github/nucleuspowered/terrafirma/Terrafirma.java
@@ -5,6 +5,7 @@ import static io.github.nucleuspowered.terrafirma.config.TerrafirmaConfig.VERSIO
 import com.google.common.collect.Lists;
 import com.google.common.reflect.TypeToken;
 import com.google.inject.Inject;
+import io.github.nucleuspowered.terrafirma.command.DumpBlockStatesCommand;
 import io.github.nucleuspowered.terrafirma.config.Layer;
 import io.github.nucleuspowered.terrafirma.config.LayerTranslator;
 import io.github.nucleuspowered.terrafirma.config.TerrafirmaConfig;
@@ -22,6 +23,7 @@ import org.slf4j.Logger;
 import org.spongepowered.api.Sponge;
 import org.spongepowered.api.asset.Asset;
 import org.spongepowered.api.block.BlockTypes;
+import org.spongepowered.api.command.spec.CommandSpec;
 import org.spongepowered.api.config.ConfigDir;
 import org.spongepowered.api.config.DefaultConfig;
 import org.spongepowered.api.event.game.GameRegistryEvent;
@@ -30,6 +32,9 @@ import org.spongepowered.api.event.Listener;
 import org.spongepowered.api.event.game.state.GamePreInitializationEvent;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.plugin.PluginContainer;
+import org.spongepowered.api.service.permission.PermissionDescription;
+import org.spongepowered.api.service.permission.PermissionService;
+import org.spongepowered.api.text.Text;
 import org.spongepowered.api.world.gen.WorldGeneratorModifier;
 
 import java.io.IOException;
@@ -51,9 +56,12 @@ public class Terrafirma {
     private final Logger logger;
     private final ConfigurationLoader<CommentedConfigurationNode> loader;
     private final Path configPath;
+    private final Path dir;
 
     @Inject
-    public Terrafirma(Logger logger, @DefaultConfig(sharedRoot = false) Path path) {
+    public Terrafirma(Logger logger,
+            @ConfigDir(sharedRoot = false) Path dir,
+            @DefaultConfig(sharedRoot = false) Path path) {
         TypeSerializerCollection typeSerializers = TypeSerializers.newCollection();
         typeSerializers.registerType(LayerTranslator.TYPE_TOKEN, LayerTranslator.INSTANCE);
         this.logger = logger;
@@ -62,11 +70,28 @@ public class Terrafirma {
                 .setDefaultOptions(ConfigurationOptions.defaults().setSerializers(typeSerializers))
                 .build();
         this.configPath = path;
+        this.dir = dir;
     }
 
     @Listener
     public void onServerStart(GamePreInitializationEvent event) {
         this.logger.info("Starting Nucleus Terrafirma");
+        Sponge.getCommandManager()
+                .register(
+                        this,
+                        CommandSpec.builder()
+                            .executor(new DumpBlockStatesCommand(this.dir))
+                            .permission("terrafirma.dumpblocks")
+                            .build(),
+                        "genblocksfile"
+                );
+        Sponge.getServiceManager()
+                .provideUnchecked(PermissionService.class)
+                .newDescriptionBuilder(this)
+                .assign(PermissionDescription.ROLE_ADMIN, true)
+                .id("terrafirma.dumpblocks")
+                .description(Text.of("Allows a user to run /genblocksfile"))
+                .register();
     }
 
     @Listener

--- a/src/main/java/io/github/nucleuspowered/terrafirma/command/DumpBlockStatesCommand.java
+++ b/src/main/java/io/github/nucleuspowered/terrafirma/command/DumpBlockStatesCommand.java
@@ -1,0 +1,72 @@
+package io.github.nucleuspowered.terrafirma.command;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.spongepowered.api.Platform;
+import org.spongepowered.api.Sponge;
+import org.spongepowered.api.block.BlockType;
+import org.spongepowered.api.command.CommandException;
+import org.spongepowered.api.command.CommandResult;
+import org.spongepowered.api.command.CommandSource;
+import org.spongepowered.api.command.args.CommandContext;
+import org.spongepowered.api.command.spec.CommandExecutor;
+import org.spongepowered.api.text.Text;
+import org.spongepowered.api.text.format.TextColors;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DumpBlockStatesCommand implements CommandExecutor {
+
+    private final Path configDirectory;
+
+    public DumpBlockStatesCommand(Path configDirectory) {
+        this.configDirectory = configDirectory;
+    }
+
+    @Override
+    @NonNull
+    public CommandResult execute(@NonNull CommandSource src, @NonNull CommandContext args) throws CommandException {
+        Path file = this.configDirectory.resolve("block_types.txt");
+        if (Files.exists(file)) {
+            throw new CommandException(Text.of(TextColors.RED, file.toString(), " already exists. Delete this file to generate a new file."));
+        }
+
+        List<String> strings = Sponge.getRegistry().getAllOf(BlockType.class)
+                .stream()
+                .map(blockType -> blockType.getTranslation().get(src.getLocale()) + " = " + blockType.getId())
+                .sorted(Comparator.naturalOrder())
+                .collect(Collectors.toList());
+
+        try (PrintWriter stream = new PrintWriter(new OutputStreamWriter(Files.newOutputStream(file, StandardOpenOption.CREATE_NEW)))) {
+            stream.println("# A list of block types to their IDs.");
+            stream.println("# Block name = block id.");
+            stream.println("# ---------------------------------- #");
+            strings.forEach(stream::println);
+            stream.println("# ---------------------------------- #");
+
+            String mName = Sponge.getPlatform().getContainer(Platform.Component.GAME).getName();
+            String mVersion = Sponge.getPlatform().getContainer(Platform.Component.GAME).getVersion().orElse("unknown");
+            String aVersion = Sponge.getPlatform().getContainer(Platform.Component.API).getVersion().orElse("unknown");
+            String fVersion = Sponge.getPlatform().getContainer(Platform.Component.IMPLEMENTATION).getName();
+            String iVersion = Sponge.getPlatform().getContainer(Platform.Component.IMPLEMENTATION).getVersion().orElse("unknown");
+
+            stream.println("Generated using:");
+            stream.println("- SpongeAPI: " + aVersion);
+            stream.println("- " + fVersion + ": " + iVersion);
+            stream.println("- " + mName + ": " + mVersion);
+        } catch (IOException e) {
+            throw new CommandException(Text.of(TextColors.RED, file.toString(), " could not be generated."), e);
+        }
+
+        src.sendMessage(Text.of(TextColors.GREEN, file.toString(), " generated."));
+        return CommandResult.success();
+    }
+
+}


### PR DESCRIPTION
Adds `/genblocksfile` to print out all the available block types on a server, such that they can be used in the Terrafirma generator modifiers.